### PR TITLE
Fix submit typo

### DIFF
--- a/src/assets/i18n/en_us.json
+++ b/src/assets/i18n/en_us.json
@@ -8,7 +8,7 @@
         },
         "dialog": {
             "header": "Announcement",
-            "message": "You are using the {0} of HFI Utility Center! Go to {1} if you want to sumbit a room application!",
+            "message": "You are using the {0} of HFI Utility Center! Go to {1} if you want to submit a room application!",
             "beta": "Beta Version"
         }
     },


### PR DESCRIPTION
## Summary
- correct a typo in the home dialog message text

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_683fabe5218c832b9ad2e2f358434efe